### PR TITLE
Add preview mode support

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -24,3 +24,4 @@ rules:
    react-hooks/rules-of-hooks: error
    react-hooks/exhaustive-deps: warn
    "@typescript-eslint/explicit-function-return-type": off
+   "@typescript-eslint/explicit-module-boundary-types": off

--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,8 @@ yarn-error.log*
 # build output
 .next
 
-# now metadata
-.now
+# vercel metadata
+.vercel
 
 # output of workbox and sw
 **/public/workbox-*.js

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,1 +1,0 @@
-yarnPath: .yarn/releases/yarn-1.22.4.js

--- a/lib/utils/notion.ts
+++ b/lib/utils/notion.ts
@@ -3,7 +3,6 @@ export async function getSlugNotion() {
     `https://notion-api.splitbee.io/v1/table/${process.env.NOTION_TABLE}`,
     {
       headers: {
-        Authorization: `Bearer ${process.env.NOTION_TOKEN}`,
         pragma: 'no-cache',
       },
     }
@@ -18,12 +17,11 @@ export async function getSlugNotion() {
   });
 }
 
-export async function getNotion() {
+export async function getPostList() {
   const res = await fetch(
     `https://notion-api.splitbee.io/v1/table/${process.env.NOTION_TABLE}`,
     {
       headers: {
-        Authorization: `Bearer ${process.env.NOTION_TOKEN}`,
         pragma: 'no-cache',
       },
     }
@@ -37,7 +35,6 @@ export async function getBlogIndex(id: any) {
     `https://notion-api.splitbee.io/v1/table/${process.env.NOTION_TABLE}`,
     {
       headers: {
-        Authorization: `Bearer ${process.env.NOTION_TOKEN}`,
         pragma: 'no-cache',
       },
     }
@@ -53,7 +50,6 @@ export async function getBlogIndex(id: any) {
 export async function getContentNotion(id: any) {
   const res = await fetch(`https://notion-api.splitbee.io/v1/page/${id}`, {
     headers: {
-      Authorization: `Bearer ${process.env.NOTION_TOKEN}`,
       pragma: 'no-cache',
     },
   });

--- a/lib/utils/notion.ts
+++ b/lib/utils/notion.ts
@@ -4,6 +4,7 @@ export async function getSlugNotion() {
     {
       headers: {
         Authorization: `Bearer ${process.env.NOTION_TOKEN}`,
+        pragma: 'no-cache',
       },
     }
   );
@@ -23,6 +24,7 @@ export async function getNotion() {
     {
       headers: {
         Authorization: `Bearer ${process.env.NOTION_TOKEN}`,
+        pragma: 'no-cache',
       },
     }
   );
@@ -36,6 +38,7 @@ export async function getBlogIndex(id: any) {
     {
       headers: {
         Authorization: `Bearer ${process.env.NOTION_TOKEN}`,
+        pragma: 'no-cache',
       },
     }
   );
@@ -51,6 +54,7 @@ export async function getContentNotion(id: any) {
   const res = await fetch(`https://notion-api.splitbee.io/v1/page/${id}`, {
     headers: {
       Authorization: `Bearer ${process.env.NOTION_TOKEN}`,
+      pragma: 'no-cache',
     },
   });
   const data = await res.json();

--- a/pages/api/clear-preview.ts
+++ b/pages/api/clear-preview.ts
@@ -1,0 +1,9 @@
+// Packages
+import { NextApiRequest, NextApiResponse } from 'next';
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  res.clearPreviewData();
+  return res.redirect('/blog');
+}
+
+export default handler;

--- a/pages/api/preview-post.ts
+++ b/pages/api/preview-post.ts
@@ -1,0 +1,42 @@
+// Packages
+import { NextApiRequest, NextApiResponse } from 'next';
+
+// Utils
+import { getBlogIndex } from '@lib/utils/notion';
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (typeof req.query.slug !== 'string') {
+    return res.status(401).json({
+      error: {
+        code: 'invalid_slug',
+        message: 'Invalid slug',
+      },
+    });
+  }
+
+  if (req.query.token !== process.env.TOKEN) {
+    return res.status(401).json({
+      error: {
+        code: 'no_authorized',
+        message: 'No authorized',
+      },
+    });
+  }
+
+  const postTable = await getBlogIndex(req.query.slug);
+  const post = postTable[0]?.Slug[0] ?? '';
+
+  if (!post) {
+    return res.status(404).json({
+      error: {
+        code: 'not_found',
+        message: `No post found for ${post}`,
+      },
+    });
+  }
+
+  res.setPreviewData({});
+  return res.redirect(`/blog/${post}`);
+}
+
+export default handler;

--- a/pages/api/preview-post.ts
+++ b/pages/api/preview-post.ts
@@ -30,7 +30,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     return res.status(404).json({
       error: {
         code: 'not_found',
-        message: `No post found for ${post}`,
+        message: `No post found for ${req.query.slug}`,
       },
     });
   }

--- a/pages/api/preview.ts
+++ b/pages/api/preview.ts
@@ -1,16 +1,35 @@
 // Packages
 import { NextApiRequest, NextApiResponse } from 'next';
 
-// Helpers
-import { getNotion } from '@lib/utils/notion';
+// Utils
+import { getPostList } from '@lib/utils/notion';
 
 async function handler(req: NextApiRequest, res: NextApiResponse) {
-  if (req.query.token !== process.env.NOTION_TOKEN) {
-    return res.status(404).json({ message: 'no_authorized' });
+  if (typeof req.query.token !== 'string') {
+    return res.status(401).json({
+      error: {
+        code: 'invalid_token',
+        message: 'Invalid token',
+      },
+    });
   }
-  const postTable = await getNotion();
+  if (req.query.token !== process.env.TOKEN) {
+    return res.status(401).json({
+      error: {
+        code: 'no_authorized',
+        message: 'No authorized',
+      },
+    });
+  }
+
+  const postTable = await getPostList();
   if (!postTable) {
-    return res.status(401).json({ message: 'Failed fetch posts' });
+    return res.status(404).json({
+      error: {
+        code: 'not_found',
+        message: 'Failed fetch posts',
+      },
+    });
   }
   res.setPreviewData({});
   res.redirect('/blog');

--- a/pages/api/preview.ts
+++ b/pages/api/preview.ts
@@ -1,0 +1,19 @@
+// Packages
+import { NextApiRequest, NextApiResponse } from 'next';
+
+// Helpers
+import { getNotion } from '@lib/utils/notion';
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.query.token !== process.env.NOTION_TOKEN) {
+    return res.status(404).json({ message: 'no_authorized' });
+  }
+  const postTable = await getNotion();
+  if (!postTable) {
+    return res.status(401).json({ message: 'Failed fetch posts' });
+  }
+  res.setPreviewData({});
+  res.redirect('/blog');
+}
+
+export default handler;

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -15,7 +15,7 @@ type NotionData = {
   Slug: string[];
   Date: string;
   Page: string;
-  Authors: object;
+  Authors: any;
 };
 
 interface BlogProps {
@@ -92,8 +92,7 @@ export const getStaticProps: GetStaticProps = async () => {
     props: {
       notionData: data,
     },
-    // eslint-disable-next-line @typescript-eslint/camelcase
-    unstable_revalidate: 1,
+    revalidate: 1,
   };
 };
 

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -7,33 +7,51 @@ import Layout from '@components/Layout';
 import Date from '@components/Date';
 
 // Utils
-import { getNotion } from '../../lib/utils/notion';
+import { getPostList } from '../../lib/utils/notion';
 
 type NotionData = {
   id: string;
-  Published: boolean;
+  Published: boolean | undefined;
   Slug: string[];
   Date: string;
   Page: string;
   Authors: any;
 };
 
-interface BlogProps {
-  notionData: NotionData[];
+interface Props {
+  posts: NotionData[];
+  preview: boolean;
 }
 
-const Blog = (props: BlogProps) => {
-  const { notionData } = props;
+const Blog = ({ posts, preview }: Props) => {
+  if (!posts.length) {
+    return (
+      <div>
+        <h1>There are no posts yet</h1>
+      </div>
+    );
+  }
   return (
     <Layout>
+      {preview && (
+        <div>
+          <span>Preview mode enable</span>
+          <Link href="/api/clear-preview">
+            <button>Exit preview</button>
+          </Link>
+        </div>
+      )}
       <ul>
-        {notionData.map((post) => (
+        {posts.map((post) => (
           <li key={post.id}>
             <span>
               <Date dateStirng={post.Date} isUpperCase />
             </span>
             <Link href="/blog/[slug]" as={`/blog/${post.Slug}`}>
-              <a>{post.Page}</a>
+              <a>
+                {!post.Published && <span style={{ color: 'red' }}>Draft</span>}
+                {post.Page}
+              </a>
             </Link>
           </li>
         ))}
@@ -84,13 +102,13 @@ const Blog = (props: BlogProps) => {
   );
 };
 
-export const getStaticProps: GetStaticProps = async () => {
-  const data = await getNotion();
-  console.log('Esta es la data');
-  console.log(data);
+export const getStaticProps: GetStaticProps = async ({ preview }) => {
+  const data: NotionData[] = await getPostList();
+  const posts = preview ? data : data.filter((post) => Boolean(post.Published));
   return {
     props: {
-      notionData: data,
+      posts,
+      preview: preview ?? false,
     },
     revalidate: 1,
   };


### PR DESCRIPTION

This PR is focusing of adding support for the preview mode. The preview mode It will not be necessary to build a development server to view the changes we make with the CMS (notion)

You can visualize that changes entering the url `you_domanin/api/preview` and providing the specific token.


## Major changes 🚀
- Add preview mode
- Ignore the rule explicit-module-boundary-types
- Remove authorization token
- Improves in handle errors
- Add preview-mode for the post
- Show the error when is not match query
- Add preview mode page blog
- Add preview mode clear endpoint
- Add preview mode


## Minor changes
- Remove unessary file
- Remove uncesary file
- Replace name  unstable_revalidate to revalidate
- Invalidation the cache the API
- Rename now to vercel metadata

