### PR TITLE
Fix path the dommain

### DIFF
--- a/lib/use-analytics.ts
+++ b/lib/use-analytics.ts
@@ -7,7 +7,7 @@ const useAnalytics = () => {
   const router = useRouter();
   useEffect(() => {
     Fathom.load(process.env.NEXT_PUBLIC_FATHOM_SITE_ID as string, {
-      includedDomains: ['markozxuu.com'],
+      includedDomains: ['www.markozxuu.com'],
     });
     function onRouteChangeComplete() {
       Fathom.trackPageview();


### PR DESCRIPTION
This PR focuses in fixing path domain fathom. Being specific, `www.acme.com` was added to what is **includedDomains**, which is the option parameter that `Fathom.load('id', {...})` receives.
